### PR TITLE
Switch to Wolverine command bus

### DIFF
--- a/src-Arius5/Arius.Cli.Tests/ArchiveCliCommandTests.cs
+++ b/src-Arius5/Arius.Cli.Tests/ArchiveCliCommandTests.cs
@@ -1,6 +1,6 @@
 using Arius.Core.Commands;
 using Arius.Core.Models;
-using MediatR;
+using Wolverine;
 using NSubstitute;
 using Shouldly;
 
@@ -17,14 +17,14 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithAllOptions_SendsCorrectMediatRCommand()
+    public async Task ExecuteAsync_WithAllOptions_SendsCorrectCommand()
     {
-        // Arrange: Capture the command sent to IMediator
+        // Arrange: Capture the command sent to IMessageBus
         ArchiveCommand? capturedCommand = null;
-        var             mediatorMock    = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var             busMock    = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         // Arrange: Set up the CLI arguments
@@ -32,11 +32,11 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var command = $"archive {tempPath} --accountname testaccount --accountkey testkey --passphrase testpass --container testcontainer";
 
         // Act: Run the application
-        var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+        var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
         // Assert: Verify the outcome
         exitCode.ShouldBe(0);
-        await mediatorMock.Received(1).Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>());
+        await busMock.Received(1).InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>());
 
         capturedCommand.ShouldNotBeNull();
         capturedCommand.LocalRoot.FullName.ShouldBe(tempPath);
@@ -67,10 +67,10 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         ArchiveCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", "true");
@@ -79,11 +79,11 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error)= await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error)= await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);
-            await mediatorMock.Received(1).Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>());
+            await busMock.Received(1).InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>());
 
             capturedCommand.ShouldNotBeNull();
             capturedCommand.LocalRoot.FullName.ShouldBe(new DirectoryInfo("/archive").FullName);
@@ -103,10 +103,10 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         ArchiveCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", null);
@@ -116,7 +116,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);
@@ -157,10 +157,10 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         ArchiveCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");
@@ -170,7 +170,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);
@@ -188,10 +188,10 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         ArchiveCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");
@@ -201,7 +201,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);

--- a/src-Arius5/Arius.Cli.Tests/CliCommandTestsFixture.cs
+++ b/src-Arius5/Arius.Cli.Tests/CliCommandTestsFixture.cs
@@ -1,5 +1,5 @@
 using CliFx.Infrastructure;
-using MediatR;
+using Wolverine;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
@@ -11,16 +11,16 @@ public class CliCommandTestsFixture
     {
     }
 
-    public async Task<(int ExitCode, string Output, string Error)> CallCliAsync(string command, IMediator? mediatorMock = null)
+    public async Task<(int ExitCode, string Output, string Error)> CallCliAsync(string command, IMessageBus? busMock = null)
     {
         using var console = new FakeInMemoryConsole();
 
-        var serviceProvider = mediatorMock is null
+        var serviceProvider = busMock is null
             ? Program.ConfigureServices(new ServiceCollection())
                 .BuildServiceProvider()
             : Program.ConfigureServices(new ServiceCollection())
-                .RemoveAll<IMediator>()
-                .AddSingleton(mediatorMock)
+                .RemoveAll<IMessageBus>()
+                .AddSingleton(busMock)
                 .BuildServiceProvider();
 
         var app = Program

--- a/src-Arius5/Arius.Cli.Tests/RestoreCliCommandTests.cs
+++ b/src-Arius5/Arius.Cli.Tests/RestoreCliCommandTests.cs
@@ -1,5 +1,5 @@
 using Arius.Core.Commands;
-using MediatR;
+using Wolverine;
 using NSubstitute;
 using Shouldly;
 
@@ -16,25 +16,25 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithAllOptions_SendsCorrectMediatRCommand()
+    public async Task ExecuteAsync_WithAllOptions_SendsCorrectCommand()
     {
         // Arrange
         RestoreCommand? capturedCommand = null;
-        var             mediatorMock    = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var             busMock    = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         var tempPath = Path.GetTempPath();
         var command = $"restore {tempPath} --accountname testaccount --accountkey testkey --passphrase testpass --container testcontainer --synchronize --download --keep-pointers";
 
         // Act
-        var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+        var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
         // Assert
         exitCode.ShouldBe(0);
-        await mediatorMock.Received(1).Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>());
+        await busMock.Received(1).InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>());
 
         capturedCommand.ShouldNotBeNull();
         capturedCommand.LocalRoot.FullName.ShouldBe(tempPath);
@@ -66,10 +66,10 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         RestoreCommand? capturedCommand = null;
-        var             mediatorMock    = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var             busMock    = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", "true");
@@ -78,11 +78,11 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);
-            await mediatorMock.Received(1).Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>());
+            await busMock.Received(1).InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>());
 
             capturedCommand.ShouldNotBeNull();
             capturedCommand.LocalRoot.FullName.ShouldBe(new DirectoryInfo("/archive").FullName);
@@ -102,10 +102,10 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         RestoreCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", null);
@@ -115,7 +115,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);
@@ -156,10 +156,10 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         RestoreCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");
@@ -169,7 +169,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);
@@ -187,10 +187,10 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
     {
         // Arrange
         RestoreCommand? capturedCommand = null;
-        var mediatorMock = Substitute.For<IMediator>();
-        mediatorMock
-            .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+        var busMock = Substitute.For<IMessageBus>();
+        busMock
+            .InvokeAsync(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
+            .Returns(Task.CompletedTask)
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");
@@ -200,7 +200,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         try
         {
             // Act
-            var (exitCode, output, error) = await fixture.CallCliAsync(command, mediatorMock);
+            var (exitCode, output, error) = await fixture.CallCliAsync(command, busMock);
 
             // Assert
             exitCode.ShouldBe(0);

--- a/src-Arius5/Arius.Cli/CliCommands/ArchiveCliCommand.cs
+++ b/src-Arius5/Arius.Cli/CliCommands/ArchiveCliCommand.cs
@@ -3,7 +3,7 @@ using Arius.Core.Models;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
-using MediatR;
+using Wolverine;
 using Spectre.Console;
 using System.Collections.Concurrent;
 
@@ -11,11 +11,11 @@ namespace Arius.Cli.CliCommands;
 
 public abstract class ArchiveCliCommandBase : ICommand
 {
-    private readonly IMediator _mediator;
+    private readonly IMessageBus _bus;
 
-    public ArchiveCliCommandBase(IMediator mediator)
+    public ArchiveCliCommandBase(IMessageBus bus)
     {
-        _mediator = mediator;
+        _bus = bus;
     }
 
     public abstract DirectoryInfo LocalRoot { get; init; }
@@ -77,7 +77,7 @@ public abstract class ArchiveCliCommandBase : ICommand
 
                     // Send the command and start the progress display loop
                     var cancellationToken = console.RegisterCancellationHandler();
-                    var commandTask       = _mediator.Send(command, cancellationToken);
+                    var commandTask       = _bus.InvokeAsync(command, cancellationToken);
 
                     var taskDictionary = new ConcurrentDictionary<string, ProgressTask>();
 
@@ -145,7 +145,7 @@ public abstract class ArchiveCliCommandBase : ICommand
 [Command("archive", Description = "Archives a local directory to Azure Blob Storage.")]
 public class ArchiveCliCommand: ArchiveCliCommandBase
 {
-    public ArchiveCliCommand(IMediator mediator) : base(mediator)
+    public ArchiveCliCommand(IMessageBus bus) : base(bus)
     {
     }
 
@@ -158,7 +158,7 @@ public class ArchiveCliCommand: ArchiveCliCommandBase
 [Command("archive", Description = "Archives a local directory to Azure Blob Storage. [Docker]")]
 public class ArchiveDockerCliCommand : ArchiveCliCommandBase
 {
-    public ArchiveDockerCliCommand(IMediator mediator) : base(mediator)
+    public ArchiveDockerCliCommand(IMessageBus bus) : base(bus)
     {
     }
 

--- a/src-Arius5/Arius.Cli/CliCommands/RestoreCliCommand.cs
+++ b/src-Arius5/Arius.Cli/CliCommands/RestoreCliCommand.cs
@@ -2,18 +2,18 @@ using Arius.Core.Commands;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
-using MediatR;
+using Wolverine;
 using Spectre.Console;
 
 namespace Arius.Cli.CliCommands;
 
 public abstract class RestoreCliCommandBase : ICommand
 {
-    private readonly IMediator mediator;
+    private readonly IMessageBus bus;
 
-    public RestoreCliCommandBase(IMediator mediator)
+    public RestoreCliCommandBase(IMessageBus bus)
     {
-        this.mediator = mediator;
+        this.bus = bus;
     }
 
     public abstract DirectoryInfo LocalRoot { get; init; }
@@ -57,7 +57,7 @@ public abstract class RestoreCliCommandBase : ICommand
             };
 
             var cancellationToken = console.RegisterCancellationHandler();
-            await mediator.Send(command, cancellationToken);
+            await bus.InvokeAsync(command, cancellationToken);
         }
         catch (Exception e)
         {
@@ -69,7 +69,7 @@ public abstract class RestoreCliCommandBase : ICommand
 [Command("restore", Description = "Restores a directory from Azure Blob Storage.")]
 public class RestoreCliCommand : RestoreCliCommandBase
 {
-    public RestoreCliCommand(IMediator mediator) : base(mediator)
+    public RestoreCliCommand(IMessageBus bus) : base(bus)
     {
     }
 
@@ -82,7 +82,7 @@ public class RestoreCliCommand : RestoreCliCommandBase
 [Command("restore", Description = "Restores a directory from Azure Blob Storage. [Docker]")]
 public class RestoreDockerCliCommand : RestoreCliCommandBase
 {
-    public RestoreDockerCliCommand(IMediator mediator) : base(mediator)
+    public RestoreDockerCliCommand(IMessageBus bus) : base(bus)
     {
     }
 

--- a/src-Arius5/Arius.Core/Arius.Core.csproj
+++ b/src-Arius5/Arius.Core/Arius.Core.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
     <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-    <PackageReference Include="MediatR" Version="12.5.0" />
+    <PackageReference Include="WolverineFx" Version="3.13.4" />
     <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="Zio" Version="0.21.0" />

--- a/src-Arius5/Arius.Core/Bootstrapper.cs
+++ b/src-Arius5/Arius.Core/Bootstrapper.cs
@@ -26,14 +26,11 @@ public static class Bootstrapper
         // Add FluentValidation validators
         //services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly()); // zie https://www.milanjovanovic.tech/blog/cqrs-validation-with-mediatr-pipeline-and-fluentvalidation#running-validation-from-the-use-case
 
-        // Add MediatR
-        services.AddMediatR(config =>
+        // Add Wolverine for command handling
+        services.AddWolverine(options =>
         {
-            // Add Handlers
-            config.RegisterServicesFromAssemblies(AppDomain.CurrentDomain.GetAssemblies());
-
-            // Add pipeline validation behavior
-            //config.AddOpenBehavior(typeof(ValidationBehavior<,>));
+            // Discover handler methods in the current AppDomain assemblies
+            options.Discovery.IncludeAssemblies(AppDomain.CurrentDomain.GetAssemblies());
         });
 
         //services.AddSingleton<IStorageAccountFactory, AzureStorageAccountFactory>();

--- a/src-Arius5/Arius.Core/Commands/ArchiveCommand.cs
+++ b/src-Arius5/Arius.Core/Commands/ArchiveCommand.cs
@@ -1,9 +1,8 @@
 ﻿using Arius.Core.Models;
-using MediatR;
 
 namespace Arius.Core.Commands;
 
-public record ArchiveCommand : IRequest
+public record ArchiveCommand
 {
     public required string        AccountName   { get; init; }
     public required string        AccountKey    { get; init; }

--- a/src-Arius5/Arius.Core/Commands/ArchiveCommandHandler.cs
+++ b/src-Arius5/Arius.Core/Commands/ArchiveCommandHandler.cs
@@ -3,7 +3,6 @@ using Arius.Core.Models;
 using Arius.Core.Repositories;
 using Arius.Core.Services;
 using Humanizer;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Formats.Tar;
@@ -19,7 +18,7 @@ public record ProgressUpdate;
 public record TaskProgressUpdate(string TaskName, double Percentage, string? StatusMessage = null) : ProgressUpdate;
 public record FileProgressUpdate(string FileName, double Percentage, string? StatusMessage = null) : ProgressUpdate;
 
-internal class ArchiveCommandHandler : IRequestHandler<ArchiveCommand>
+internal class ArchiveCommandHandler
 {
     private readonly ILogger<ArchiveCommandHandler> logger;
     private readonly IOptions<AriusConfiguration>   config;

--- a/src-Arius5/Arius.Core/Commands/RestoreCommand.cs
+++ b/src-Arius5/Arius.Core/Commands/RestoreCommand.cs
@@ -1,10 +1,9 @@
-using MediatR;
 using System.IO;
 using Arius.Core.Models;
 
 namespace Arius.Core.Commands;
 
-public record RestoreCommand : IRequest
+public record RestoreCommand
 {
     public required string        AccountName   { get; init; }
     public required string        AccountKey    { get; init; }

--- a/src-Arius5/Arius.Core/Commands/RestoreCommandHandler.cs
+++ b/src-Arius5/Arius.Core/Commands/RestoreCommandHandler.cs
@@ -2,7 +2,6 @@ using Arius.Core.Extensions;
 using Arius.Core.Models;
 using Arius.Core.Repositories;
 using Arius.Core.Services;
-using MediatR;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Zio;
@@ -10,7 +9,7 @@ using Zio.FileSystems;
 
 namespace Arius.Core.Commands;
 
-internal class RestoreCommandHandler : IRequestHandler<RestoreCommand>
+internal class RestoreCommandHandler
 {
     private readonly ILogger<RestoreCommandHandler> logger;
     private readonly IOptions<AriusConfiguration> config;

--- a/src-Arius5/CLAUDE.md
+++ b/src-Arius5/CLAUDE.md
@@ -12,7 +12,7 @@ Arius is a file archival system that encrypts, compresses, and uploads files to 
 
 ## Architecture
 
-The codebase follows a **CQRS pattern** using MediatR for command handling. The main workflow is implemented in `ArchiveCommandHandler` which:
+The codebase follows a **CQRS pattern** using Wolverine for command handling. The main workflow is implemented in `ArchiveCommandHandler` which:
 
 1. **Indexes** files from a local directory using the Zio filesystem abstraction
 2. **Hashes** files in parallel using SHA256
@@ -69,7 +69,7 @@ The CLI application requires configuration via user secrets:
 
 ## Key Dependencies
 
-- **MediatR**: CQRS command/query handling
+- **Wolverine**: CQRS command/query handling
 - **Zio**: Cross-platform filesystem abstraction
 - **Azure.Storage.Blobs**: Azure Blob Storage client
 - **Entity Framework Core**: SQLite persistence


### PR DESCRIPTION
## Summary
- swap MediatR for Wolverine
- adjust bootstrapper and command handlers
- refactor CLI commands and tests to use `IMessageBus`
- document the new Wolverine dependency

## Testing
- `dotnet test src-Arius5/Arius.sln` *(fails: NU1107 version conflicts)*

------
https://chatgpt.com/codex/tasks/task_e_684d45dc6620832c8fc84c4d4e73c1b5