### PR TITLE
chore: upgrade src-Arius5 projects to .NET 9

### DIFF
--- a/src-Arius5/Arius.Cli.Tests/Arius.Cli.Tests.csproj
+++ b/src-Arius5/Arius.Cli.Tests/Arius.Cli.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src-Arius5/Arius.Cli/Arius.Cli.csproj
+++ b/src-Arius5/Arius.Cli/Arius.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <UserSecretsId>2c53e63e-555d-44f4-a474-29c01fb8c564</UserSecretsId>
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CliFx" Version="2.3.6" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.8" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />

--- a/src-Arius5/Arius.Core.Tests/Arius.Core.Tests.csproj
+++ b/src-Arius5/Arius.Core.Tests/Arius.Core.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
 
@@ -15,14 +15,14 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-	  <PackageReference Include="FluentAssertions" Version="7.2.0" />
-	  <PackageReference Include="JunitXml.TestLogger" Version="5.0.0" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.6.0" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.6" />
-	  <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.6" />
+          <PackageReference Include="FluentAssertions" Version="7.2.0" />
+          <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
+          <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
+          <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />
+          <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" Version="9.8.0" />
+          <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.8" />
+          <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="9.0.8" />
+          <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="9.0.8" />
 	  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
 	  <PackageReference Include="NSubstitute" Version="5.3.0" />
 	  <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17">
@@ -30,7 +30,7 @@
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
 	  <PackageReference Include="xunit" Version="2.9.3" />
-	  <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+          <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>

--- a/src-Arius5/Arius.Core/Arius.Core.csproj
+++ b/src-Arius5/Arius.Core/Arius.Core.csproj
@@ -1,24 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-	<TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
 	<ImplicitUsings>false</ImplicitUsings>
 	<Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Azure.Storage.Blobs" Version="12.24.0" />
+        <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
 	<PackageReference Include="Humanizer.Core" Version="2.14.1" />
-	<PackageReference Include="MediatR" Version="12.5.0" />
-	<PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.5" />
-	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
+        <PackageReference Include="MediatR" Version="12.5.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.8" />
+        <PackageReference Include="System.Linq.Async" Version="6.0.3" />
 	<PackageReference Include="Zio" Version="0.21.0" />
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8">
 		<PrivateAssets>all</PrivateAssets>
 		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	</PackageReference>
-	<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
-	<PackageReference Include="WouterVanRanst.Utils" Version="2.0.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
+        <PackageReference Include="WouterVanRanst.Utils" Version="2.0.4" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- target .NET 9 across CLI, Core, and test projects in `src-Arius5`
- update NuGet dependencies, retaining WouterVanRanst.Utils 2.0.4, MediatR 12.5, and FluentAssertions 7.2
- revert `SqliteStateDatabaseContext` to prior `RemovePrefix` behavior

## Testing
- `dotnet restore src-Arius5/Arius.sln`
- `dotnet list src-Arius5/Arius.sln package --outdated`
- `dotnet test src-Arius5/Arius.sln` *(fails: The configuration file 'secrets.json' was not found and is not optional)*

------
https://chatgpt.com/codex/tasks/task_b_68a97b1bb9c88324a4f5d69e3ea8ff36