### PR TITLE
chore: replace FluentAssertions with Shouldly

### DIFF
--- a/src-Arius5/Arius.Core.Tests/Arius.Core.Tests.csproj
+++ b/src-Arius5/Arius.Core.Tests/Arius.Core.Tests.csproj
@@ -15,7 +15,7 @@
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 	  </PackageReference>
-          <PackageReference Include="FluentAssertions" Version="7.2.0" />
+          <PackageReference Include="Shouldly" Version="4.3.0" />
           <PackageReference Include="JunitXml.TestLogger" Version="6.1.0" />
           <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.8" />
           <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.8" />

--- a/src-Arius5/Arius.Core.Tests/Commands/ArchiveCommandHandlerContextTests.cs
+++ b/src-Arius5/Arius.Core.Tests/Commands/ArchiveCommandHandlerContextTests.cs
@@ -2,10 +2,10 @@ using Arius.Core.Commands;
 using Arius.Core.Models;
 using Arius.Core.Repositories;
 using Arius.Core.Services;
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
 using NSubstitute;
+using Shouldly;
 
 namespace Arius.Core.Tests.Commands;
 
@@ -63,17 +63,17 @@ public class ArchiveCommandHandlerContextCreateAsyncTests : IDisposable
             tempStateDirectory);
 
         // Assert
-        context.Should().NotBeNull();
-        context.Request.Should().Be(testCommand);
-        context.BlobStorage.Should().Be(mockBlobStorage);
-        context.StateRepo.Should().NotBeNull();
-        context.Hasher.Should().NotBeNull();
-        context.FileSystem.Should().NotBeNull();
+        context.ShouldNotBeNull();
+        context.Request.ShouldBe(testCommand);
+        context.BlobStorage.ShouldBe(mockBlobStorage);
+        context.StateRepo.ShouldNotBeNull();
+        context.Hasher.ShouldNotBeNull();
+        context.FileSystem.ShouldNotBeNull();
 
         // Verify a new state file was created (with current timestamp format)
         var stateFiles = tempStateDirectory.GetFiles("*.db");
-        stateFiles.Should().HaveCount(1);
-        stateFiles[0].Name.Should().MatchRegex(@"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.db");
+        stateFiles.Length.ShouldBe(1);
+        stateFiles[0].Name.ShouldMatch(@"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.db");
 
         // Verify no download was attempted since no remote state exists
         await mockBlobStorage.DidNotReceive().DownloadStateAsync(Arg.Any<string>(), Arg.Any<FileInfo>(), Arg.Any<CancellationToken>());
@@ -104,9 +104,9 @@ public class ArchiveCommandHandlerContextCreateAsyncTests : IDisposable
             tempStateDirectory);
 
         // Assert
-        context.Should().NotBeNull();
-        context.Request.Should().Be(testCommand);
-        context.BlobStorage.Should().Be(mockBlobStorage);
+        context.ShouldNotBeNull();
+        context.Request.ShouldBe(testCommand);
+        context.BlobStorage.ShouldBe(mockBlobStorage);
 
         // Verify the remote state was downloaded
         await mockBlobStorage.Received(1).DownloadStateAsync(
@@ -116,15 +116,15 @@ public class ArchiveCommandHandlerContextCreateAsyncTests : IDisposable
 
         // Verify a new state file was created (with current timestamp format)
         var stateFiles = tempStateDirectory.GetFiles("*.db");
-        stateFiles.Should().HaveCountGreaterThan(0);
+        stateFiles.Length.ShouldBeGreaterThan(0);
         
         // Should have the downloaded state file and the new version
         var downloadedStateFile = stateFiles.FirstOrDefault(f => f.Name == $"{existingStateName}.db");
-        downloadedStateFile.Should().NotBeNull("the downloaded state file should exist");
+        downloadedStateFile.ShouldNotBeNull("the downloaded state file should exist");
         
         var newStateFile = stateFiles.FirstOrDefault(f => f.Name != $"{existingStateName}.db");
-        newStateFile.Should().NotBeNull("a new state file should be created");
-        newStateFile.Name.Should().MatchRegex(@"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.db");
+        newStateFile.ShouldNotBeNull("a new state file should be created");
+        newStateFile.Name.ShouldMatch(@"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.db");
     }
 
     [Fact]
@@ -147,24 +147,24 @@ public class ArchiveCommandHandlerContextCreateAsyncTests : IDisposable
             tempStateDirectory);
 
         // Assert
-        context.Should().NotBeNull();
-        context.Request.Should().Be(testCommand);
-        context.BlobStorage.Should().Be(mockBlobStorage);
+        context.ShouldNotBeNull();
+        context.Request.ShouldBe(testCommand);
+        context.BlobStorage.ShouldBe(mockBlobStorage);
 
         // Verify no download was attempted since the file already exists locally
         await mockBlobStorage.DidNotReceive().DownloadStateAsync(Arg.Any<string>(), Arg.Any<FileInfo>(), Arg.Any<CancellationToken>());
 
         // Verify a new state file was created (with current timestamp format)
         var stateFiles = tempStateDirectory.GetFiles("*.db");
-        stateFiles.Should().HaveCountGreaterThan(1);
+        stateFiles.Length.ShouldBeGreaterThan(1);
         
         // Should have the existing state file and the new version
         var existingFile = stateFiles.FirstOrDefault(f => f.Name == $"{existingStateName}.db");
-        existingFile.Should().NotBeNull("the existing state file should still exist");
+        existingFile.ShouldNotBeNull("the existing state file should still exist");
         
         var newStateFile = stateFiles.FirstOrDefault(f => f.Name != $"{existingStateName}.db");
-        newStateFile.Should().NotBeNull("a new state file should be created");
-        newStateFile.Name.Should().MatchRegex(@"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.db");
+        newStateFile.ShouldNotBeNull("a new state file should be created");
+        newStateFile.Name.ShouldMatch(@"\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}\.db");
     }
 
     public void Dispose()

--- a/src-Arius5/Arius.Core.Tests/Commands/ArchiveCommandHandlerErrorTests.cs
+++ b/src-Arius5/Arius.Core.Tests/Commands/ArchiveCommandHandlerErrorTests.cs
@@ -1,8 +1,8 @@
 using Arius.Core.Commands;
 using Arius.Core.Models;
-using FluentAssertions;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Logging.Testing;
+using Shouldly;
 
 namespace Arius.Core.Tests.Commands;
 
@@ -50,8 +50,8 @@ public class ArchiveCommandHandlerErrorTests : IDisposable
         var act = () => handler.Handle(command, CancellationToken.None);
 
         // Assert
-        var e = await act.Should().ThrowAsync<FormatException>();
-        e.Which.Message.Should().Contain("No valid combination of account information found.");
+        var e = await Should.ThrowAsync<FormatException>(act);
+        e.Message.ShouldContain("No valid combination of account information found.");
     }
 
     public void Dispose()

--- a/src-Arius5/Arius.Core.Tests/Models/FilePairFileSystemTests.cs
+++ b/src-Arius5/Arius.Core.Tests/Models/FilePairFileSystemTests.cs
@@ -1,5 +1,5 @@
 using Arius.Core.Models;
-using FluentAssertions;
+using Shouldly;
 using Zio;
 
 namespace Arius.Core.Tests.Models;
@@ -47,6 +47,8 @@ public class FilePairFileSystemTests : IClassFixture<Fixture>
         Assert.NotNull(files);
         Assert.Equal(expectedRelativePaths.Length, files.Count);
 
-        files.Select(fe => fe.FullName).Should().BeEquivalentTo(expectedRelativePaths);
+        files.Select(fe => fe.FullName)
+            .OrderBy(p => p)
+            .ShouldBe(expectedRelativePaths.OrderBy(p => p));
     }
 }

--- a/src-Arius5/Arius.Core.Tests/Models/HashTests.cs
+++ b/src-Arius5/Arius.Core.Tests/Models/HashTests.cs
@@ -1,5 +1,5 @@
 using Arius.Core.Models;
-using FluentAssertions;
+using Shouldly;
 
 namespace Arius.Core.Tests.Models;
 
@@ -11,10 +11,10 @@ public class HashTests
         Hash h1 = "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD";
         Hash h2 = "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD";
 
-        h1.Equals(h2).Should().BeTrue();
-        h1.GetHashCode().Should().Be(h2.GetHashCode());
+        h1.Equals(h2).ShouldBeTrue();
+        h1.GetHashCode().ShouldBe(h2.GetHashCode());
 
-        (h1 == h2).Should().BeTrue();
+        (h1 == h2).ShouldBeTrue();
     }
 
     [Fact]
@@ -23,7 +23,7 @@ public class HashTests
         Hash h1 = "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD";
         Hash h2 = "ABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCDABCD".ToLowerInvariant();
 
-        h1.Equals(h2).Should().BeTrue();
-        h1.GetHashCode().Should().Be(h2.GetHashCode());
+        h1.Equals(h2).ShouldBeTrue();
+        h1.GetHashCode().ShouldBe(h2.GetHashCode());
     }
 }

--- a/src-Arius5/Arius.Core.Tests/Services/Sha256HasherTest.cs
+++ b/src-Arius5/Arius.Core.Tests/Services/Sha256HasherTest.cs
@@ -1,6 +1,6 @@
 using Arius.Core.Models;
 using Arius.Core.Services;
-using FluentAssertions;
+using Shouldly;
 using Zio;
 using Zio.FileSystems;
 
@@ -18,7 +18,7 @@ public class Sha256HasherTest
         var hash1 = await hasher.GetHashAsync(zeroBytes);
 
         var arius3HasherHash = (Hash)"88e667ac1167d96e7c42ec65daf9c096d374263a313c60b6d307ec3938300f98";
-        hash1.Should().Be(arius3HasherHash);
+        hash1.ShouldBe(arius3HasherHash);
     }
 
     [Fact]
@@ -38,6 +38,6 @@ public class Sha256HasherTest
         var hash1 = await hasher.GetHashAsync(bf);
 
         var arius3HasherHash = (Hash)"88e667ac1167d96e7c42ec65daf9c096d374263a313c60b6d307ec3938300f98";
-        hash1.Should().Be(arius3HasherHash);
+        hash1.ShouldBe(arius3HasherHash);
     }
 }

--- a/src-Arius5/CLAUDE.md
+++ b/src-Arius5/CLAUDE.md
@@ -74,4 +74,4 @@ The CLI application requires configuration via user secrets:
 - **Azure.Storage.Blobs**: Azure Blob Storage client
 - **Entity Framework Core**: SQLite persistence
 - **Spectre.Console**: Rich console UI with progress reporting
-- **xUnit**: Test framework with FluentAssertions and NSubstitute
+- **xUnit**: Test framework with Shouldly and NSubstitute


### PR DESCRIPTION
## Summary
- swap FluentAssertions for Shouldly in Arius.Core.Tests
- update tests to use Shouldly assertions
- reflect new assertion library in documentation

## Testing
- `~/.dotnet/dotnet test Arius.sln` *(fails: No valid combination of account information found, some tests require Azure credentials)*

------
https://chatgpt.com/codex/tasks/task_b_68a981b15574832492066d246e1ed80d