### PR TITLE
Switch to Mediator in Arius5

### DIFF
--- a/src-Arius5/Arius.Cli.Tests/ArchiveCliCommandTests.cs
+++ b/src-Arius5/Arius.Cli.Tests/ArchiveCliCommandTests.cs
@@ -1,6 +1,6 @@
 using Arius.Core.Commands;
 using Arius.Core.Models;
-using MediatR;
+using Mediator;
 using NSubstitute;
 using Shouldly;
 
@@ -17,14 +17,14 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithAllOptions_SendsCorrectMediatRCommand()
+    public async Task ExecuteAsync_WithAllOptions_SendsCorrectMediatorCommand()
     {
         // Arrange: Capture the command sent to IMediator
         ArchiveCommand? capturedCommand = null;
         var             mediatorMock    = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         // Arrange: Set up the CLI arguments
@@ -70,7 +70,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", "true");
@@ -106,7 +106,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", null);
@@ -160,7 +160,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");
@@ -191,7 +191,7 @@ public sealed class ArchiveCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<ArchiveCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<ArchiveCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");

--- a/src-Arius5/Arius.Cli.Tests/CliCommandTestsFixture.cs
+++ b/src-Arius5/Arius.Cli.Tests/CliCommandTestsFixture.cs
@@ -1,5 +1,5 @@
 using CliFx.Infrastructure;
-using MediatR;
+using Mediator;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 

--- a/src-Arius5/Arius.Cli.Tests/RestoreCliCommandTests.cs
+++ b/src-Arius5/Arius.Cli.Tests/RestoreCliCommandTests.cs
@@ -1,5 +1,5 @@
 using Arius.Core.Commands;
-using MediatR;
+using Mediator;
 using NSubstitute;
 using Shouldly;
 
@@ -16,14 +16,14 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
     }
 
     [Fact]
-    public async Task ExecuteAsync_WithAllOptions_SendsCorrectMediatRCommand()
+    public async Task ExecuteAsync_WithAllOptions_SendsCorrectMediatorCommand()
     {
         // Arrange
         RestoreCommand? capturedCommand = null;
         var             mediatorMock    = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         var tempPath = Path.GetTempPath();
@@ -69,7 +69,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var             mediatorMock    = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER", "true");
@@ -105,7 +105,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", null);
@@ -159,7 +159,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");
@@ -190,7 +190,7 @@ public sealed class RestoreCliCommandTests : IClassFixture<CliCommandTestsFixtur
         var mediatorMock = Substitute.For<IMediator>();
         mediatorMock
             .Send(Arg.Any<RestoreCommand>(), Arg.Any<CancellationToken>())
-            .Returns(Task.FromResult(Unit.Value))
+            .Returns(new ValueTask<Unit>(Unit.Value))
             .AndDoes(callInfo => capturedCommand = callInfo.Arg<RestoreCommand>());
 
         Environment.SetEnvironmentVariable("ARIUS_ACCOUNT_KEY", "testkeyenv");

--- a/src-Arius5/Arius.Cli/Arius.Cli.csproj
+++ b/src-Arius5/Arius.Cli/Arius.Cli.csproj
@@ -16,6 +16,11 @@
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="Spectre.Console" Version="0.50.0" />
+    <PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
+    <PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src-Arius5/Arius.Cli/CliCommands/ArchiveCliCommand.cs
+++ b/src-Arius5/Arius.Cli/CliCommands/ArchiveCliCommand.cs
@@ -3,13 +3,13 @@ using Arius.Core.Models;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
-using MediatR;
+using Mediator;
 using Spectre.Console;
 using System.Collections.Concurrent;
 
 namespace Arius.Cli.CliCommands;
 
-public abstract class ArchiveCliCommandBase : ICommand
+public abstract class ArchiveCliCommandBase : CliFx.ICommand
 {
     private readonly IMediator _mediator;
 
@@ -62,7 +62,7 @@ public abstract class ArchiveCliCommandBase : ICommand
                     var queue = new ConcurrentQueue<ProgressUpdate>();
                     var pu = new Progress<ProgressUpdate>(u => queue.Enqueue(u));
 
-                    // Create the MediatR command from the CLI arguments
+                    // Create the Mediator command from the CLI arguments
                     var command = new ArchiveCommand
                     {
                         AccountName      = AccountName,
@@ -77,7 +77,7 @@ public abstract class ArchiveCliCommandBase : ICommand
 
                     // Send the command and start the progress display loop
                     var cancellationToken = console.RegisterCancellationHandler();
-                    var commandTask       = _mediator.Send(command, cancellationToken);
+                    var commandTask       = _mediator.Send(command, cancellationToken).AsTask();
 
                     var taskDictionary = new ConcurrentDictionary<string, ProgressTask>();
 

--- a/src-Arius5/Arius.Cli/CliCommands/RestoreCliCommand.cs
+++ b/src-Arius5/Arius.Cli/CliCommands/RestoreCliCommand.cs
@@ -2,12 +2,12 @@ using Arius.Core.Commands;
 using CliFx;
 using CliFx.Attributes;
 using CliFx.Infrastructure;
-using MediatR;
+using Mediator;
 using Spectre.Console;
 
 namespace Arius.Cli.CliCommands;
 
-public abstract class RestoreCliCommandBase : ICommand
+public abstract class RestoreCliCommandBase : CliFx.ICommand
 {
     private readonly IMediator mediator;
 

--- a/src-Arius5/Arius.Core.Tests/Commands/ArchiveCommandHandlerErrorTests.cs
+++ b/src-Arius5/Arius.Core.Tests/Commands/ArchiveCommandHandlerErrorTests.cs
@@ -47,7 +47,7 @@ public class ArchiveCommandHandlerErrorTests : IDisposable
         };
 
         // Act
-        var act = () => handler.Handle(command, CancellationToken.None);
+        var act = () => handler.Handle(command, CancellationToken.None).AsTask();
 
         // Assert
         var e = await Should.ThrowAsync<FormatException>(act);

--- a/src-Arius5/Arius.Core/Arius.Core.csproj
+++ b/src-Arius5/Arius.Core/Arius.Core.csproj
@@ -8,8 +8,12 @@
 
   <ItemGroup>
         <PackageReference Include="Azure.Storage.Blobs" Version="12.25.0" />
-	<PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="MediatR" Version="12.5.0" />
+        <PackageReference Include="Humanizer.Core" Version="2.14.1" />
+        <PackageReference Include="Mediator.Abstractions" Version="3.0.1" />
+        <PackageReference Include="Mediator.SourceGenerator" Version="3.0.1">
+                <PrivateAssets>all</PrivateAssets>
+                <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="9.0.8" />
         <PackageReference Include="System.Linq.Async" Version="6.0.3" />
 	<PackageReference Include="Zio" Version="0.21.0" />

--- a/src-Arius5/Arius.Core/Bootstrapper.cs
+++ b/src-Arius5/Arius.Core/Bootstrapper.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
 using System.ComponentModel.DataAnnotations;
+using Mediator;
 
 namespace Arius.Core;
 
@@ -26,15 +27,8 @@ public static class Bootstrapper
         // Add FluentValidation validators
         //services.AddValidatorsFromAssembly(Assembly.GetExecutingAssembly()); // zie https://www.milanjovanovic.tech/blog/cqrs-validation-with-mediatr-pipeline-and-fluentvalidation#running-validation-from-the-use-case
 
-        // Add MediatR
-        services.AddMediatR(config =>
-        {
-            // Add Handlers
-            config.RegisterServicesFromAssemblies(AppDomain.CurrentDomain.GetAssemblies());
-
-            // Add pipeline validation behavior
-            //config.AddOpenBehavior(typeof(ValidationBehavior<,>));
-        });
+        // Add Mediator
+        services.AddMediator();
 
         //services.AddSingleton<IStorageAccountFactory, AzureStorageAccountFactory>();
         //services.AddSingleton<AzureContainerFactory>();

--- a/src-Arius5/Arius.Core/Commands/ArchiveCommand.cs
+++ b/src-Arius5/Arius.Core/Commands/ArchiveCommand.cs
@@ -1,9 +1,9 @@
 ﻿using Arius.Core.Models;
-using MediatR;
+using Mediator;
 
 namespace Arius.Core.Commands;
 
-public record ArchiveCommand : IRequest
+public record ArchiveCommand : ICommand
 {
     public required string        AccountName   { get; init; }
     public required string        AccountKey    { get; init; }

--- a/src-Arius5/Arius.Core/Commands/ArchiveCommandHandler.cs
+++ b/src-Arius5/Arius.Core/Commands/ArchiveCommandHandler.cs
@@ -3,12 +3,13 @@ using Arius.Core.Models;
 using Arius.Core.Repositories;
 using Arius.Core.Services;
 using Humanizer;
-using MediatR;
+using Mediator;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Formats.Tar;
 using System.IO.Compression;
 using System.Threading.Channels;
+using System.Threading.Tasks;
 using WouterVanRanst.Utils.Extensions;
 using Zio;
 using Zio.FileSystems;
@@ -19,7 +20,7 @@ public record ProgressUpdate;
 public record TaskProgressUpdate(string TaskName, double Percentage, string? StatusMessage = null) : ProgressUpdate;
 public record FileProgressUpdate(string FileName, double Percentage, string? StatusMessage = null) : ProgressUpdate;
 
-internal class ArchiveCommandHandler : IRequestHandler<ArchiveCommand>
+internal class ArchiveCommandHandler : ICommandHandler<ArchiveCommand>
 {
     private readonly ILogger<ArchiveCommandHandler> logger;
     private readonly ILoggerFactory                 loggerFactory;
@@ -44,7 +45,7 @@ internal class ArchiveCommandHandler : IRequestHandler<ArchiveCommand>
 
     private record FilePairWithHash(FilePair FilePair, Hash Hash);
 
-    public async Task Handle(ArchiveCommand request, CancellationToken cancellationToken)
+    public async ValueTask<Unit> Handle(ArchiveCommand request, CancellationToken cancellationToken)
     {
         var handlerContext = await HandlerContext.CreateAsync(request, loggerFactory);
 
@@ -132,6 +133,8 @@ internal class ArchiveCommandHandler : IRequestHandler<ArchiveCommand>
 
             throw;
         }
+
+        return Unit.Value;
     }
 
     private Task CreateIndexTask(HandlerContext handlerContext, CancellationToken cancellationToken, CancellationTokenSource errorCancellationTokenSource) =>

--- a/src-Arius5/Arius.Core/Commands/RestoreCommand.cs
+++ b/src-Arius5/Arius.Core/Commands/RestoreCommand.cs
@@ -1,10 +1,10 @@
-using MediatR;
+using Mediator;
 using System.IO;
 using Arius.Core.Models;
 
 namespace Arius.Core.Commands;
 
-public record RestoreCommand : IRequest
+public record RestoreCommand : ICommand
 {
     public required string        AccountName   { get; init; }
     public required string        AccountKey    { get; init; }

--- a/src-Arius5/Arius.Core/Commands/RestoreCommandHandler.cs
+++ b/src-Arius5/Arius.Core/Commands/RestoreCommandHandler.cs
@@ -2,15 +2,16 @@ using Arius.Core.Extensions;
 using Arius.Core.Models;
 using Arius.Core.Repositories;
 using Arius.Core.Services;
-using MediatR;
+using Mediator;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Zio;
 using Zio.FileSystems;
+using System.Threading.Tasks;
 
 namespace Arius.Core.Commands;
 
-internal class RestoreCommandHandler : IRequestHandler<RestoreCommand>
+internal class RestoreCommandHandler : ICommandHandler<RestoreCommand>
 {
     private readonly ILogger<RestoreCommandHandler> logger;
     private readonly IOptions<AriusConfiguration> config;
@@ -23,7 +24,7 @@ internal class RestoreCommandHandler : IRequestHandler<RestoreCommand>
         this.config = config;
     }
 
-    public async Task Handle(RestoreCommand request, CancellationToken cancellationToken)
+    public async ValueTask<Unit> Handle(RestoreCommand request, CancellationToken cancellationToken)
     {
         var handlerContext = await HandlerContext.CreateAsync(request);
 
@@ -52,6 +53,8 @@ internal class RestoreCommandHandler : IRequestHandler<RestoreCommand>
             logger.LogError(e, $"Error restoring chunk '{chunkHash.ToShortString()}'");
             throw;
         }
+
+        return Unit.Value;
     }
 
     private class HandlerContext

--- a/src-Arius5/Arius.Core/InternalsVisibleTo.cs
+++ b/src-Arius5/Arius.Core/InternalsVisibleTo.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
 
+[assembly: InternalsVisibleTo("arius")]
 [assembly: InternalsVisibleTo("Arius.Core.Tests")]
 [assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]


### PR DESCRIPTION
## Summary
- replace MediatR with Mediator library and source generator
- adjust commands, handlers, CLI, and tests for Mediator APIs
- expose core internals to CLI

## Testing
- `dotnet build`
- `dotnet test` *(fails: No valid combination of account information found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9ac5eaee88324aa30be6270f1a91a