### PR TITLE
chore: build and release arius cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,17 @@ on:
   push:
     branches:
       - '**'
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'src/**'
+  pull_request:
+    paths:
+      - '.github/workflows/ci.yml'
+      - 'src/**'
+  workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   actions: read
   checks: write
 
@@ -58,3 +66,64 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
+
+  build:
+    name: Build and Release
+    runs-on: ubuntu-latest
+    needs: test
+    defaults:
+      run:
+        working-directory: src
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.x
+
+      - name: Determine version
+        id: get_version
+        run: |
+          BASE_VERSION=$(grep -Po '(?<=<Version>)[^<]+' Arius.Cli/Arius.Cli.csproj | head -n 1)
+          BASE_VERSION=${BASE_VERSION/\$\(GITHUB_RUN_NUMBER\)/$GITHUB_RUN_NUMBER}
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            echo "VERSION=${BASE_VERSION}" >> $GITHUB_ENV
+            echo "IS_PRERELEASE=false" >> $GITHUB_ENV
+          else
+            echo "VERSION=${BASE_VERSION}-prerelease" >> $GITHUB_ENV
+            echo "IS_PRERELEASE=true" >> $GITHUB_ENV
+          fi
+
+      - name: Publish
+        run: dotnet publish Arius.Cli/Arius.Cli.csproj --configuration Release --output publish
+
+      - name: Package artifact
+        run: tar czf arius-cli-${VERSION}.tar.gz -C publish .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: arius-cli-${{ env.VERSION }}
+          path: arius-cli-${{ env.VERSION }}.tar.gz
+
+      - name: Login to Docker Hub
+        run: echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
+
+      - name: Build and Push Docker Image
+        run: |
+          IMAGE_NAME="${{ secrets.DOCKERHUB_USERNAME }}/arius5:${VERSION}"
+          docker build -t $IMAGE_NAME -f Arius.Cli/Dockerfile .
+          docker push $IMAGE_NAME
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: v${{ env.VERSION }}
+          prerelease: ${{ env.IS_PRERELEASE == 'true' }}
+          files: arius-cli-${{ env.VERSION }}.tar.gz
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/src/Arius.Cli/Dockerfile
+++ b/src/Arius.Cli/Dockerfile
@@ -1,41 +1,11 @@
-# Local build
-# in /src/
-# docker build -f Arius.Cli\Dockerfile . -t arius
-
-# Local run (in cmd.exe, not WSL)
-# docker run -it arius /bin/sh
-
-
-# Use the official .NET SDK image for building the application
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
-WORKDIR /src
-
-# Copy the solution and project files
-COPY ["Arius.Cli/Arius.Cli.csproj", "Arius.Cli/"]
-COPY ["Arius.Core/Arius.Core.csproj", "Arius.Core/"]
-
-# Restore dependencies
-RUN dotnet restore "Arius.Cli/Arius.Cli.csproj"
-
-# Copy the remaining source code and build the application
-COPY . .
-WORKDIR "Arius.Cli"
-RUN dotnet build "Arius.Cli.csproj" -c Release -o /app/build
-
-# Publish the application
-FROM build AS publish
-RUN dotnet publish "Arius.Cli.csproj" -c Release -o /app/publish /p:UseAppHost=false
-
-# Use the official .NET runtime image for the final application
-FROM mcr.microsoft.com/dotnet/runtime:8.0 AS final
+FROM mcr.microsoft.com/dotnet/runtime:8.0
 WORKDIR /app
 
-# Copy the published application
-COPY --from=publish /app/publish .
+# Copy the prebuilt artifacts into the image
+COPY publish/ .
 
 # Define mount points for archive and logs
 VOLUME /archive
 VOLUME /logs
 
-# Set the entry point for the application
 ENTRYPOINT ["dotnet", "arius.dll"]


### PR DESCRIPTION
## Summary
- run CI on workflow changes and push/pr for src
- build, package, and release Arius.Cli after tests
- push Docker image and create GitHub release using csproj version
- simplify Dockerfile to copy prebuilt artifacts into runtime image

## Testing
- `dotnet build src/Arius.sln --configuration Release`
- `dotnet test src/Arius.sln --configuration Release --no-build` *(fails: System.IO.DirectoryNotFoundException : Could not find a part of the path `/mnt/c/Users/WouterVanRanst/Downloads/Photos-001 (1)`)*

------
https://chatgpt.com/codex/tasks/task_b_68aa94c132b0832495fb660d97079c5f