### PR TITLE
Include commit list in GitHub releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,3 +169,5 @@ jobs:
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v1 # see https://github.com/softprops/action-gh-release for options
+      with:
+        generate_release_notes: true


### PR DESCRIPTION
## Summary
- enable auto-generated release notes so releases show commits since the previous tag

## Testing
- `dotnet test` *(fails: Could not find a part of the path `/mnt/c/Users/WouterVanRanst/Downloads/Photos-001 (1)`)*

------
https://chatgpt.com/codex/tasks/task_b_68aedfe00da0832493fa4bbfceb6d9f3