### PR TITLE
chore: migrate to xunit v3

### DIFF
--- a/src/Arius.Cli.Tests/Arius.Cli.Tests.csproj
+++ b/src/Arius.Cli.Tests/Arius.Cli.Tests.csproj
@@ -21,7 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Shouldly" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Arius.Core.Tests/Arius.Core.Tests.csproj
+++ b/src/Arius.Core.Tests/Arius.Core.Tests.csproj
@@ -29,8 +29,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="TngTech.ArchUnitNET.xUnit" />
-		<PackageReference Include="xunit" />
+                <PackageReference Include="TngTech.ArchUnitNET" />
+                <PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Arius.Core.Tests/Utils.cs
+++ b/src/Arius.Core.Tests/Utils.cs
@@ -1,7 +1,7 @@
 using Arius.Core.Tests.Helpers.Fixtures;
 using Azure.Storage.Blobs;
 using Azure.Storage.Blobs.Models;
-using Xunit.Abstractions;
+using Xunit;
 
 namespace Arius.Core.Tests;
 

--- a/src/Arius.Explorer.Tests/Arius.Explorer.Tests.csproj
+++ b/src/Arius.Explorer.Tests/Arius.Explorer.Tests.csproj
@@ -26,8 +26,8 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="TngTech.ArchUnitNET.xUnit" />
-		<PackageReference Include="xunit" />
+                <PackageReference Include="TngTech.ArchUnitNET" />
+                <PackageReference Include="xunit.v3" />
 		<PackageReference Include="xunit.runner.visualstudio">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -37,9 +37,9 @@
     <PackageVersion Include="Shouldly" Version="4.3.0" />
     <PackageVersion Include="Spectre.Console" Version="0.51.1" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.3" />
-    <PackageVersion Include="TngTech.ArchUnitNET.xUnit" Version="0.12.1" />
+    <PackageVersion Include="TngTech.ArchUnitNET" Version="0.12.1" />
     <PackageVersion Include="WouterVanRanst.Utils" Version="2.0.8" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.v3" Version="3.0.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.4" />
     <PackageVersion Include="Zio" Version="0.21.0" />
     <PackageVersion Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />


### PR DESCRIPTION
## Summary
- update the central package list and all test projects to reference `xunit.v3`
- drop the `TngTech.ArchUnitNET.xUnit` dependency in favor of the core `TngTech.ArchUnitNET` library
- adjust the test utility to use the new `ITestOutputHelper` namespace exposed by xUnit v3

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68ca5996a5e8832497a1b6f75dbf16a9